### PR TITLE
Add PreSignChangeEvent

### DIFF
--- a/Spigot-API-Patches/0067-event-Add-PreSignChangeEvent.patch
+++ b/Spigot-API-Patches/0067-event-Add-PreSignChangeEvent.patch
@@ -1,0 +1,114 @@
+From 119a0ba1bef6c3342116e8d65f6b52b4cbce9f99 Mon Sep 17 00:00:00 2001
+From: Archer <archer@beezig.eu>
+Date: Thu, 13 Jan 2022 00:26:17 +0100
+Subject: [PATCH] event: Add PreSignChangeEvent
+
+This commit adds an event that's called *before* an incoming sign change
+is processed by the server. This event is useful to handle invalid sign
+changes that are dismissed by the server before the regular
+SignChangeEvent is called.
+
+diff --git a/src/main/java/dev/rocco/kig/paper/api/event/PreSignChangeEvent.java b/src/main/java/dev/rocco/kig/paper/api/event/PreSignChangeEvent.java
+new file mode 100644
+index 00000000..65a10f5d
+--- /dev/null
++++ b/src/main/java/dev/rocco/kig/paper/api/event/PreSignChangeEvent.java
+@@ -0,0 +1,95 @@
++package dev.rocco.kig.paper.api.event;
++
++import org.bukkit.Location;
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.Event;
++import org.bukkit.event.HandlerList;
++
++/**
++ * Called before a sign change by a player is processed. If you only want to listen for
++ * successful sign changes, use {@link org.bukkit.event.block.SignChangeEvent} instead.
++ * The {@code PreSignChangeEvent} is only useful if the events that you want to listen
++ * for can be cancelled by the server e.g. because the sign that the player tries to
++ * edit doesn't exist.
++ *
++ * <p>If you cancel this event, the sign will not be changed. Moreover, the server still
++ * checks whether the sign change is valid, and its checks and the SignChangeEvent can
++ * still prevent the sign change if you don't cancel this event.
++ */
++public class PreSignChangeEvent extends Event implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    private final Player player;
++    private final String[] lines;
++    private final Location location;
++    private boolean cancelled = false;
++
++    /**
++     * Creates a new {@code PreSignChangeEvent} for the given block, player, and changed
++     * lines.
++     *
++     * @param location the location to create this event for
++     * @param player   the player that initiate the sign change
++     * @param lines    the lines that the sign was changed to in this event
++     */
++    public PreSignChangeEvent(Location location, Player player, String[] lines) {
++        this.player = player;
++        this.lines = lines;
++        this.location = location;
++    }
++
++    /**
++     * Returns the list of handlers that handle a {@code PreSignChangeEvent}.
++     */
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++
++    /**
++     * Returns the player that involved this sign change event.
++     */
++    public Player getPlayer() {
++        return player;
++    }
++
++    /**
++     * Returns the lines that the sign's content was set to
++     */
++    public String[] getLines() {
++        return lines;
++    }
++
++    /**
++     * Returns the location of the block that this event was called for. The block at this location is <b>not</b>
++     * guaranteed to exist.
++     */
++    public Location getLocation() {
++        return location;
++    }
++
++    /**
++     * Returns whether this event has been cancelled
++     */
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    /**
++     * Sets the cancelled status for this event
++     *
++     * @param cancel true if you wish to cancel this event
++     */
++    @Override
++    public void setCancelled(boolean cancel) {
++        cancelled = cancel;
++    }
++
++    /**
++     * Returns the list of handlers for the {@code PreSignChangeEvent}
++     */
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++}
+-- 
+2.34.1
+

--- a/Spigot-Server-Patches/0227-event-Add-PreSignChangeEvent.patch
+++ b/Spigot-Server-Patches/0227-event-Add-PreSignChangeEvent.patch
@@ -1,0 +1,68 @@
+From 19adb7b4de01049d0307da079fb5f31ca59b1a91 Mon Sep 17 00:00:00 2001
+From: Archer <archer@beezig.eu>
+Date: Thu, 13 Jan 2022 01:49:56 +0100
+Subject: [PATCH] event: Add PreSignChangeEvent
+
+This commit adds an event that's called *before* an incoming sign change
+is processed by the server. This event is useful to handle invalid sign
+changes that are dismissed by the server before the regular
+SignChangeEvent is called.
+
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index 2c6c1e2bc..1aa0d226c 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -4,7 +4,7 @@ import com.google.common.collect.Lists;
+ import com.google.common.primitives.Doubles;
+ import com.google.common.primitives.Floats;
+ import dev.rocco.kig.paper.api.event.DisconnectReason;
+-import dev.rocco.kig.paper.api.event.PlayerInteractUpdateEvent;
++import dev.rocco.kig.paper.api.event.PreSignChangeEvent;
+ import dev.rocco.kig.paper.impl.event.KigEvents;
+ import io.netty.buffer.Unpooled;
+ import io.netty.util.concurrent.Future;
+@@ -1939,6 +1939,22 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
+     public void a(PacketPlayInUpdateSign packetplayinupdatesign) {
+         if (this.player.dead) return; // CraftBukkit
+         PlayerConnectionUtils.ensureMainThread(packetplayinupdatesign, this, this.player.u());
++        // KigPaper start
++        Player player = this.server.getPlayer(this.player);
++        int x = packetplayinupdatesign.a().getX();
++        int y = packetplayinupdatesign.a().getY();
++        int z = packetplayinupdatesign.a().getZ();
++        IChatBaseComponent[] aichatbasecomponent = packetplayinupdatesign.b();
++        String[] lines = new String[4];
++
++        for (int i = 0; i < aichatbasecomponent.length; ++i) {
++            lines[i] = EnumChatFormat.a(aichatbasecomponent[i].c());
++        }
++        PreSignChangeEvent preSignChangeEvent =
++                new PreSignChangeEvent(new Location(player.getWorld(), x, y, z), player, lines);
++        this.server.getPluginManager().callEvent(preSignChangeEvent);
++        if (preSignChangeEvent.isCancelled()) return;
++        // KigPaper end
+         this.player.resetIdleTimer();
+         WorldServer worldserver = this.minecraftServer.getWorldServer(this.player.dimension);
+         BlockPosition blockposition = packetplayinupdatesign.a();
+@@ -1958,18 +1974,7 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
+                 return;
+             }
+ 
+-            IChatBaseComponent[] aichatbasecomponent = packetplayinupdatesign.b();
+-
+             // CraftBukkit start
+-            Player player = this.server.getPlayer(this.player);
+-            int x = packetplayinupdatesign.a().getX();
+-            int y = packetplayinupdatesign.a().getY();
+-            int z = packetplayinupdatesign.a().getZ();
+-            String[] lines = new String[4];
+-
+-            for (int i = 0; i < aichatbasecomponent.length; ++i) {
+-                lines[i] = EnumChatFormat.a(aichatbasecomponent[i].c());
+-            }
+             SignChangeEvent event = new SignChangeEvent((org.bukkit.craftbukkit.block.CraftBlock) player.getWorld().getBlockAt(x, y, z), this.server.getPlayer(this.player), lines);
+             this.server.getPluginManager().callEvent(event);
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
This PR adds an event that's called before a sign change is processed.
The event is handy for sign GUIs and other (non-vanilla) sign changes that rely on "invalid" sign updates to get input from a player.

From testing, the code seems to work just fine. However, I moved some lines in front of the vanilla "sanity checks". When reviewing this PR, this should be double-checked.