### PR TITLE
Update JUnit4 and Guava

### DIFF
--- a/Spigot-API-Patches/0069-build-Update-JUnit4-and-Guava-dependencies.patch
+++ b/Spigot-API-Patches/0069-build-Update-JUnit4-and-Guava-dependencies.patch
@@ -1,0 +1,67 @@
+From 1659f35f9a70f0752f6cc7c91a2b620f67830b26 Mon Sep 17 00:00:00 2001
+From: Archer <archer@beezig.eu>
+Date: Thu, 24 Mar 2022 05:19:24 +0100
+Subject: [PATCH] build: Update JUnit4 and Guava dependencies
+
+This commit updates JUnit4 to prevent possible information exposure with
+the `TemporaryFolder` test rule. The project currently uses this rule,
+but due to the nature of a public free software project, the data
+exposed by this vulnerability is not of great value to a potential local
+attacker. As the dependency was declared with scope `test`, running
+servers weren't affected by the vulnerability.
+
+CVE: CVE-2020-15250
+GHSA: GHSA-269g-pwp5-87pp
+
+Additionally, this commit updates Guava to prevent two possible
+vulnerabilities:
+
+Deserializing attacker-provided data could lead to a denial of service
+because `AtomicDoubleArray` when serialized with Java serialization and
+`CompoundOrdering` when serialized with GWT serialization performed no
+appropriate checks whether the user-provided data has a reasonable size.
+KigPaper doesn't seem affected by this vulnerability, but given that
+Guava is a runtime dependency, it should still be updated.
+
+CVE: CVE-2018-10237
+
+Temporary directories created with
+`com.google.common.io.Files#createTempDir()` would be readable by an
+attacker with local access to the system. While updating the dependency
+does *not* fix this security vulnerability, the method has been
+deprecated in Guava 30. It is advised to "use
+`java.nio.file.Files#createTempDirectory`, transforming it to a `File`
+using `java.nio.file.Path#toFile()` if needed". KigPaper doesn't seem
+affected by this vulnerability as the method in question is never
+invoked. Nevertheless, this dependency should be updated to hint the
+projects reusing the server's Guava library to switch to the safe
+alternative mentioned in the deprecation notice (and quoted in this
+commit).
+
+CVE: CVE-2020-8908
+
+diff --git a/pom.xml b/pom.xml
+index 6c22adc2..8e88aa3a 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -71,7 +71,7 @@
+         <dependency>
+             <groupId>com.google.guava</groupId>
+             <artifactId>guava</artifactId>
+-            <version>17.0</version>
++            <version>31.1-jre</version>
+             <scope>compile</scope>
+         </dependency>
+         <!-- bundled with Minecraft, should be kept in sync -->
+@@ -104,7 +104,7 @@
+         <dependency>
+             <groupId>junit</groupId>
+             <artifactId>junit</artifactId>
+-            <version>4.12</version>
++            <version>4.13.2</version>
+             <scope>test</scope>
+         </dependency>
+         <dependency>
+-- 
+2.35.1
+

--- a/Spigot-Server-Patches/0231-build-Update-JUnit4-and-Guava-dependencies.patch
+++ b/Spigot-Server-Patches/0231-build-Update-JUnit4-and-Guava-dependencies.patch
@@ -1,0 +1,202 @@
+From 49f08f28086bb9a6336a4f861790ae3a6223ac5c Mon Sep 17 00:00:00 2001
+From: Archer <archer@beezig.eu>
+Date: Thu, 24 Mar 2022 04:48:31 +0100
+Subject: [PATCH] build: Update JUnit4 and Guava dependencies
+
+This commit updates JUnit4 to prevent possible information exposure with
+the `TemporaryFolder` test rule. The project currently uses this rule,
+but due to the nature of a public free software project, the data
+exposed by this vulnerability is not of great value to a potential local
+attacker. As the dependency was declared with scope `test`, running
+servers weren't affected by the vulnerability. Nevertheless, this
+vulnerability should be fixed.
+
+CVE: CVE-2020-15250
+GHSA: GHSA-269g-pwp5-87pp
+
+Additionally, this commit applies necessary changes for the updated
+Guava version used in PaperSpigot-API.
+
+diff --git a/pom.xml b/pom.xml
+index 53909e286..f4047f9a5 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -11,7 +11,7 @@
+     <properties>
+         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+         <api.version>unknown</api.version>
+-        <junit.version>4.11</junit.version>
++        <junit.version>4.13.2</junit.version>
+         <minecraft.version>1.8.8</minecraft.version>
+         <minecraft_version>1_8_R3</minecraft_version>
+         <buildtag.prefix>git-Bukkit-</buildtag.prefix>
+diff --git a/src/main/java/net/minecraft/server/BaseBlockPosition.java b/src/main/java/net/minecraft/server/BaseBlockPosition.java
+index a685e0812..678426d48 100644
+--- a/src/main/java/net/minecraft/server/BaseBlockPosition.java
++++ b/src/main/java/net/minecraft/server/BaseBlockPosition.java
+@@ -1,6 +1,6 @@
+ package net.minecraft.server;
+ 
+-import com.google.common.base.Objects;
++import com.google.common.base.MoreObjects; // KigPaper
+ 
+ public class BaseBlockPosition implements Comparable<BaseBlockPosition> {
+ 
+@@ -80,7 +80,7 @@ public class BaseBlockPosition implements Comparable<BaseBlockPosition> {
+     }
+ 
+     public String toString() {
+-        return Objects.toStringHelper(this).add("x", this.getX()).add("y", this.getY()).add("z", this.getZ()).toString();
++        return MoreObjects.toStringHelper(this).add("x", this.getX()).add("y", this.getY()).add("z", this.getZ()).toString(); // KigPaper
+     }
+ 
+     // Paperspigot - Signature change, Object -> BaseBlockPosition
+diff --git a/src/main/java/net/minecraft/server/BlockTripwireHook.java b/src/main/java/net/minecraft/server/BlockTripwireHook.java
+index 0ad4a20f3..2534043d8 100644
+--- a/src/main/java/net/minecraft/server/BlockTripwireHook.java
++++ b/src/main/java/net/minecraft/server/BlockTripwireHook.java
+@@ -1,6 +1,6 @@
+ package net.minecraft.server;
+ 
+-import com.google.common.base.Objects;
++import com.google.common.base.MoreObjects; // KigPaper
+ import com.google.common.base.Predicate;
+ import java.util.Iterator;
+ import java.util.Random;
+@@ -113,7 +113,7 @@ public class BlockTripwireHook extends Block {
+                 flag5 = false;
+             } else {
+                 if (k == i) {
+-                    iblockdata2 = (IBlockData) Objects.firstNonNull(iblockdata1, iblockdata2);
++                    iblockdata2 = (IBlockData) MoreObjects.firstNonNull(iblockdata1, iblockdata2); // KigPaper
+                 }
+ 
+                 boolean flag7 = !((Boolean) iblockdata2.get(BlockTripwire.DISARMED)).booleanValue();
+diff --git a/src/main/java/net/minecraft/server/EntitySlice.java b/src/main/java/net/minecraft/server/EntitySlice.java
+index ae6c52f2c..75be862a4 100644
+--- a/src/main/java/net/minecraft/server/EntitySlice.java
++++ b/src/main/java/net/minecraft/server/EntitySlice.java
+@@ -5,6 +5,7 @@ import com.google.common.collect.Lists;
+ import com.google.common.collect.Maps;
+ import com.google.common.collect.Sets;
+ import java.util.AbstractSet;
++import java.util.Collections; // KigPaper
+ import java.util.Iterator;
+ import java.util.List;
+ import java.util.Map;
+@@ -114,7 +115,7 @@ public class EntitySlice<T> extends AbstractSet<T> {
+                 List list = (List) EntitySlice.this.b.get(EntitySlice.this.b(oclass));
+ 
+                 if (list == null) {
+-                    return Iterators.emptyIterator();
++                    return Collections.emptyIterator(); // KigPaper
+                 } else {
+                     Iterator iterator = list.iterator();
+ 
+@@ -125,7 +126,7 @@ public class EntitySlice<T> extends AbstractSet<T> {
+     }
+ 
+     public Iterator<T> iterator() {
+-        return this.e.isEmpty() ? Iterators.<T>emptyIterator() : Iterators.unmodifiableIterator(this.e.iterator());
++        return this.e.isEmpty() ? Collections.emptyIterator() : Iterators.unmodifiableIterator(this.e.iterator()); // KigPaper
+     }
+ 
+     public int size() {
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index 1a571d136..2c590403d 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -1592,7 +1592,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+             try {
+                 return Futures.immediateFuture(callable.call());
+             } catch (Exception exception) {
+-                return Futures.immediateFailedCheckedFuture(exception);
++                return Futures.immediateFailedFuture(exception); // KigPaper
+             }
+         }
+     }
+diff --git a/src/main/java/net/minecraft/server/PacketPlayOutPlayerInfo.java b/src/main/java/net/minecraft/server/PacketPlayOutPlayerInfo.java
+index 50300bff9..bc6b1ed74 100644
+--- a/src/main/java/net/minecraft/server/PacketPlayOutPlayerInfo.java
++++ b/src/main/java/net/minecraft/server/PacketPlayOutPlayerInfo.java
+@@ -1,6 +1,6 @@
+ package net.minecraft.server;
+ 
+-import com.google.common.base.Objects;
++import com.google.common.base.MoreObjects; // KigPaper
+ import com.google.common.collect.Lists;
+ import com.mojang.authlib.GameProfile;
+ import com.mojang.authlib.properties.Property;
+@@ -254,7 +254,7 @@ public class PacketPlayOutPlayerInfo implements Packet<PacketListenerPlayOut> {
+     }
+ 
+     public String toString() {
+-        return Objects.toStringHelper(this).add("action", this.a).add("entries", this.b).toString();
++        return MoreObjects.toStringHelper(this).add("action", this.a).add("entries", this.b).toString(); // KigPaper
+     }
+     /* KigPaper - fix compile error
+     public void a(PacketListener packetlistener) {
+@@ -340,7 +340,7 @@ public class PacketPlayOutPlayerInfo implements Packet<PacketListenerPlayOut> {
+         }
+ 
+         public String toString() {
+-            return Objects.toStringHelper(this).add("latency", this.b).add("gameMode", this.c).add("profile", this.d).add("displayName", this.e == null ? null : IChatBaseComponent.ChatSerializer.a(this.e)).toString();
++            return MoreObjects.toStringHelper(this).add("latency", this.b).add("gameMode", this.c).add("profile", this.d).add("displayName", this.e == null ? null : IChatBaseComponent.ChatSerializer.a(this.e)).toString(); // KigPaper
+         }
+     }
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index f7a1f322e..6c3e46902 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -6,9 +6,12 @@ import com.avaje.ebean.config.dbplatform.SQLitePlatform;
+ import com.avaje.ebeaninternal.server.lib.sql.TransactionIsolation;
+ import com.google.common.base.Charsets;
+ import com.google.common.base.Function;
++// KigPaper Start
++import com.google.common.cache.Cache;
++import com.google.common.cache.CacheBuilder;
++// KigPaper End
+ import com.google.common.collect.ImmutableList;
+ import com.google.common.collect.Lists;
+-import com.google.common.collect.MapMaker;
+ import com.mojang.authlib.GameProfile;
+ import dev.rocco.kig.paper.api.skin.SkinCache;
+ import dev.rocco.kig.paper.api.velocity.KnockbackValues;
+@@ -101,7 +104,7 @@ public final class CraftServer implements Server {
+     private YamlConfiguration configuration;
+     private YamlConfiguration commandsConfiguration;
+     private final Yaml yaml = new Yaml(new SafeConstructor());
+-    private final Map<UUID, OfflinePlayer> offlinePlayers = new MapMaker().softValues().makeMap();
++    private final Cache<UUID, OfflinePlayer> offlinePlayers = CacheBuilder.newBuilder().softValues().build(); // KigPaper
+     /*
+     private final EntityMetadataStore entityMetadata = new EntityMetadataStore();
+     private final PlayerMetadataStore playerMetadata = new PlayerMetadataStore();
+@@ -1349,7 +1352,7 @@ public final class CraftServer implements Server {
+                 result = getOfflinePlayer(profile);
+             }
+         } else {
+-            offlinePlayers.remove(result.getUniqueId());
++            offlinePlayers.invalidate(result.getUniqueId()); // KigPaper
+         }
+ 
+         return result;
+@@ -1361,13 +1364,13 @@ public final class CraftServer implements Server {
+ 
+         OfflinePlayer result = getPlayer(id);
+         if (result == null) {
+-            result = offlinePlayers.get(id);
++            result = offlinePlayers.getIfPresent(id); // KigPaper
+             if (result == null) {
+                 result = new CraftOfflinePlayer(this, new GameProfile(id, null));
+                 offlinePlayers.put(id, result);
+             }
+         } else {
+-            offlinePlayers.remove(id);
++            offlinePlayers.invalidate(id); // KigPaper
+         }
+ 
+         return result;
+-- 
+2.35.1
+


### PR DESCRIPTION
This patch updates the JUnit4 and Guava dependencies to prevent possible security vulnerabilities.
I described all vulnerabilities in the commit message. Moreover, the CVEs below give additional information.

**None of the vulnerabilities** seems like a serious threat. We're not affected (in this project) by most of them, their severity is either minor or medium, and the potentially exposed data would be build data for public free software anyway.

## Testing notes

It should be tested whether this update impacts our current infrastructure. While the JUnit4 update shouldn't affect users, the Guava update might remove deprecated elements or introduce other breaking changes.

## References

Junit4

CVE: CVE-2020-15250
GHSA: GHSA-269g-pwp5-87pp

---

Guava

1. CVE: CVE-2018-10237
2. CVE: CVE-2020-8908