### PR TITLE
Upgrade Guava in untouched NMS classes

### DIFF
--- a/nms-patches/BlockState.patch
+++ b/nms-patches/BlockState.patch
@@ -1,0 +1,21 @@
+diff --git a/src/main/java/net/minecraft/server/BlockState.java b/src/main/java/net/minecraft/server/BlockState.java
+index 3cada5afc..0934322e4 100644
+--- a/src/main/java/net/minecraft/server/BlockState.java
++++ b/src/main/java/net/minecraft/server/BlockState.java
+@@ -1,6 +1,6 @@
+ package net.minecraft.server;
+ 
+-import com.google.common.base.Objects;
++import com.google.common.base.MoreObjects; // KigPaper
+ 
+ public abstract class BlockState<T extends Comparable<T>> implements IBlockState<T> {
+ 
+@@ -21,7 +21,7 @@ public abstract class BlockState<T extends Comparable<T>> implements IBlockState
+     }
+ 
+     public String toString() {
+-        return Objects.toStringHelper(this).add("name", this.b).add("clazz", this.a).add("values", this.c()).toString();
++        return MoreObjects.toStringHelper(this).add("name", this.b).add("clazz", this.a).add("values", this.c()).toString(); // KigPaper
+     }
+ 
+     public boolean equals(Object object) {

--- a/nms-patches/BlockStateList.patch
+++ b/nms-patches/BlockStateList.patch
@@ -1,0 +1,31 @@
+diff --git a/src/main/java/net/minecraft/server/BlockStateList.java b/src/main/java/net/minecraft/server/BlockStateList.java
+index 8a815a64c..9823bf2e0 100644
+--- a/src/main/java/net/minecraft/server/BlockStateList.java
++++ b/src/main/java/net/minecraft/server/BlockStateList.java
+@@ -2,7 +2,7 @@ package net.minecraft.server;
+ 
+ import com.google.common.base.Function;
+ import com.google.common.base.Joiner;
+-import com.google.common.base.Objects;
++import com.google.common.base.MoreObjects; // KigPaper
+ import com.google.common.collect.HashBasedTable;
+ import com.google.common.collect.ImmutableList;
+ import com.google.common.collect.ImmutableMap;
+@@ -101,7 +101,7 @@ public class BlockStateList {
+     }
+ 
+     public String toString() {
+-        return Objects.toStringHelper(this).add("block", Block.REGISTRY.c(this.c)).add("properties", Iterables.transform(this.d, BlockStateList.b)).toString();
++        return MoreObjects.toStringHelper(this).add("block", Block.REGISTRY.c(this.c)).add("properties", Iterables.transform(this.d, BlockStateList.b)).toString(); // KigPaper
+     }
+ 
+     static class BlockData extends BlockDataAbstract {
+@@ -123,7 +123,7 @@ public class BlockStateList {
+             if (!this.b.containsKey(iblockstate)) {
+                 throw new IllegalArgumentException("Cannot get property " + iblockstate + " as it does not exist in " + this.a.P());
+             } else {
+-                return (Comparable) iblockstate.b().cast(this.b.get(iblockstate));
++                return iblockstate.b().cast(this.b.get(iblockstate)); // KigPaper
+             }
+         }
+ 

--- a/nms-patches/ShapeDetector.patch
+++ b/nms-patches/ShapeDetector.patch
@@ -1,0 +1,32 @@
+diff --git a/src/main/java/net/minecraft/server/ShapeDetector.java b/src/main/java/net/minecraft/server/ShapeDetector.java
+index 325dcc6ae..8aa0bf9fe 100644
+--- a/src/main/java/net/minecraft/server/ShapeDetector.java
++++ b/src/main/java/net/minecraft/server/ShapeDetector.java
+@@ -1,6 +1,6 @@
+ package net.minecraft.server;
+ 
+-import com.google.common.base.Objects;
++import com.google.common.base.MoreObjects; // KigPaper
+ import com.google.common.base.Predicate;
+ import com.google.common.cache.CacheBuilder;
+ import com.google.common.cache.CacheLoader;
+@@ -146,7 +146,7 @@ public class ShapeDetector {
+         }
+ 
+         public String toString() {
+-            return Objects.toStringHelper(this).add("up", this.c).add("forwards", this.b).add("frontTopLeft", this.a).toString();
++            return MoreObjects.toStringHelper(this).add("up", this.c).add("forwards", this.b).add("frontTopLeft", this.a).toString(); // KigPaper
+         }
+     }
+ 
+@@ -164,7 +164,9 @@ public class ShapeDetector {
+             return new ShapeDetectorBlock(this.a, blockposition, this.b);
+         }
+ 
+-        public Object load(Object object) throws Exception {
++        // KigPaper
++        @Override
++        public ShapeDetectorBlock load(BlockPosition object) throws Exception {
+             return this.a((BlockPosition) object);
+         }
+     }

--- a/nms-patches/StructureBoundingBox.patch
+++ b/nms-patches/StructureBoundingBox.patch
@@ -1,0 +1,21 @@
+diff --git a/src/main/java/net/minecraft/server/StructureBoundingBox.java b/src/main/java/net/minecraft/server/StructureBoundingBox.java
+index d6c2aac9f..d9f557e62 100644
+--- a/src/main/java/net/minecraft/server/StructureBoundingBox.java
++++ b/src/main/java/net/minecraft/server/StructureBoundingBox.java
+@@ -1,6 +1,6 @@
+ package net.minecraft.server;
+ 
+-import com.google.common.base.Objects;
++import com.google.common.base.MoreObjects; // KigPaper
+ 
+ public class StructureBoundingBox {
+ 
+@@ -139,7 +139,7 @@ public class StructureBoundingBox {
+     }
+ 
+     public String toString() {
+-        return Objects.toStringHelper(this).add("x0", this.a).add("y0", this.b).add("z0", this.c).add("x1", this.d).add("y1", this.e).add("z1", this.f).toString();
++        return MoreObjects.toStringHelper(this).add("x0", this.a).add("y0", this.b).add("z0", this.c).add("x1", this.d).add("y1", this.e).add("z1", this.f).toString(); // KigPaper
+     }
+ 
+     public NBTTagIntArray g() {

--- a/nms-patches/WorldGenCaves.patch
+++ b/nms-patches/WorldGenCaves.patch
@@ -1,0 +1,22 @@
+diff --git a/src/main/java/net/minecraft/server/WorldGenCaves.java b/src/main/java/net/minecraft/server/WorldGenCaves.java
+index 2cdd02378..f68019a29 100644
+--- a/src/main/java/net/minecraft/server/WorldGenCaves.java
++++ b/src/main/java/net/minecraft/server/WorldGenCaves.java
+@@ -1,6 +1,6 @@
+ package net.minecraft.server;
+ 
+-import com.google.common.base.Objects;
++import com.google.common.base.MoreObjects; // KigPaper
+ import java.util.Random;
+ 
+ public class WorldGenCaves extends WorldGenBase {
+@@ -140,7 +140,8 @@ public class WorldGenCaves extends WorldGenBase {
+ 
+                                         if (d14 > -0.7D && d12 * d12 + d14 * d14 + d13 * d13 < 1.0D) {
+                                             IBlockData iblockdata1 = chunksnapshot.a(j3, j4, i4);
+-                                            IBlockData iblockdata2 = (IBlockData) Objects.firstNonNull(chunksnapshot.a(j3, j4 + 1, i4), Blocks.AIR.getBlockData());
++                                            IBlockData iblockdata2 =
++                                                MoreObjects.firstNonNull(chunksnapshot.a(j3, j4 + 1, i4), Blocks.AIR.getBlockData()); // KigPaper
+ 
+                                             if (iblockdata1.getBlock() == Blocks.GRASS || iblockdata1.getBlock() == Blocks.MYCELIUM) {
+                                                 flag3 = true;


### PR DESCRIPTION
This PR is a follow-up to #11. While #11 updated Guava in all NMS classes that Bukkit applied changes to,
some classes remained unchanged in Bukkit. Instead of recompiling these classes, the build infrastructure
left them untouched in the server binary.
Thus, the server would throw `NoSuchMethodException`s when generating terrain and possibly, when
dealing with block states.

The API changes in this PR were simple `Objects` -> `MoreObjects` changes, so they shouldn't break any
existing behaviour. However, when reviewing this PR, we should double-check that I found all removed
Guava methods.

Thanks in advance for the review :slightly_smiling_face: 