### PR TITLE
metadata: add better BlockMetadataStore

### DIFF
--- a/Benchmarks/pom.xml
+++ b/Benchmarks/pom.xml
@@ -49,6 +49,11 @@
             <artifactId>jopt-simple</artifactId>
             <version>5.0.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <version>0.16</version>
+        </dependency>
     </dependencies>
 
     <!-- This builds a completely 'ready to start' jar with all dependencies inside -->
@@ -95,6 +100,10 @@
                         <relocation>
                             <pattern>net.minecraft.server.v1_8_R3</pattern>
                             <shadedPattern>net.minecraft.server</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.bukkit.craftbukkit.v1_8_R3</pattern>
+                            <shadedPattern>org.bukkit.craftbukkit</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>

--- a/Benchmarks/src/main/java/org/bukkit/block/Block.java
+++ b/Benchmarks/src/main/java/org/bukkit/block/Block.java
@@ -1,0 +1,16 @@
+package org.bukkit.block;
+
+import org.bukkit.World;
+
+/**
+ * Overwritten to only use the methods we need
+ */
+public interface Block {
+    int getX();
+
+    int getY();
+
+    int getZ();
+
+    World getWorld();
+}

--- a/Benchmarks/src/main/java/org/bukkit/metadata/BlockMetadataStoreBenchmark.java
+++ b/Benchmarks/src/main/java/org/bukkit/metadata/BlockMetadataStoreBenchmark.java
@@ -1,0 +1,190 @@
+package org.bukkit.metadata;
+
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.craftbukkit.metadata.BlockMetadataStore;
+import org.bukkit.craftbukkit.metadata.SpecializedBlockMetadataStore;
+import org.bukkit.plugin.Plugin;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jol.info.GraphLayout;
+
+@State(Scope.Thread)
+public class BlockMetadataStoreBenchmark {
+    private static MetadataStore<Block> oldStore;
+    private static MetadataStore<Block> newStore;
+    private static Block[] blocks;
+    private static Plugin owningPlugin; // Need the reference to stay alive
+    private static String key;
+    private static MetadataValue value;
+
+    @State(Scope.Benchmark)
+    public static class OldStoreRead {
+        MetadataStore<Block> populatedStore;
+        Plugin owningPlugin;
+
+        @Setup(Level.Invocation) // Need to generate each time - value might be altered
+        public void setup() {
+            owningPlugin = new TestPlugin();
+            populatedStore = new BlockMetadataStore(null);
+            MetadataValue value = new FixedMetadataValue(owningPlugin, 2);
+            for (Block block : generateBlocks()) {
+                populatedStore.setMetadata(block, "READ-KEY", value);
+            }
+        }
+    }
+
+    @State(Scope.Benchmark)
+    public static class NewStoreRead {
+        MetadataStore<Block> populatedStore;
+        Plugin owningPlugin;
+
+        @Setup(Level.Invocation) // Need to generate each time - value might be altered
+        public void setup() {
+            owningPlugin = new TestPlugin();
+            populatedStore = new SpecializedBlockMetadataStore(null);
+            MetadataValue value = new FixedMetadataValue(owningPlugin, 2);
+            for (Block block : generateBlocks()) {
+                populatedStore.setMetadata(block, "READ-KEY", value);
+            }
+        }
+    }
+
+    @Setup(Level.Trial)
+    public void once() {
+        Block[] blocks = generateBlocks();
+
+        MetadataStore<Block> oldStore = new BlockMetadataStore(null);
+        MetadataStore<Block> newStore = new SpecializedBlockMetadataStore(null);
+        MetadataValue value = new FixedMetadataValue(new TestPlugin(), 2);
+
+        for (Block block : blocks) {
+            oldStore.setMetadata(block, "SIZE-KEY", value);
+            newStore.setMetadata(block, "SIZE-KEY", value);
+        }
+
+        System.out.println();
+        System.out.println("Memory usage comparison (bytes, " + blocks.length + " blocks registered)");
+        System.out.println("Old store: " + GraphLayout.parseInstance(oldStore).totalSize());
+        System.out.println("New store: " + GraphLayout.parseInstance(newStore).totalSize());
+        System.out.println();
+    }
+
+    @Setup(Level.Invocation) // Need to generate each time - value might be altered
+    public void init() {
+        owningPlugin = new TestPlugin();
+        key = "TEST-KEY-123";
+        value = new FixedMetadataValue(owningPlugin, 1);
+        oldStore = new BlockMetadataStore(null);
+        newStore = new SpecializedBlockMetadataStore(null);
+        blocks = generateBlocks();
+    }
+
+    @Benchmark
+    public void insertOld(Blackhole blackhole) {
+        for (Block block : blocks) {
+            oldStore.setMetadata(block, key, value);
+        }
+        blackhole.consume(oldStore);
+    }
+
+    @Benchmark
+    public void insertNew(Blackhole blackhole) {
+        for (Block block : blocks) {
+            newStore.setMetadata(block, key, value);
+        }
+        blackhole.consume(newStore);
+    }
+
+    @Benchmark
+    public void getOld(Blackhole blackhole, OldStoreRead state) {
+        for (Block block : blocks) {
+            blackhole.consume(state.populatedStore.getMetadata(block, key));
+        }
+    }
+
+    @Benchmark
+    public void getNew(Blackhole blackhole, NewStoreRead state) {
+        for (Block block : blocks) {
+            blackhole.consume(state.populatedStore.getMetadata(block, key));
+        }
+    }
+
+    @Benchmark
+    public void hasOld(Blackhole blackhole, OldStoreRead state) {
+        for (Block block : blocks) {
+            blackhole.consume(state.populatedStore.hasMetadata(block, key));
+        }
+    }
+
+    @Benchmark
+    public void hasNew(Blackhole blackhole, NewStoreRead state) {
+        for (Block block : blocks) {
+            blackhole.consume(state.populatedStore.hasMetadata(block, key));
+        }
+    }
+
+    @Benchmark
+    public void removeOld(Blackhole blackhole, OldStoreRead state) {
+        for (Block block : blocks) {
+            state.populatedStore.removeMetadata(block, key, state.owningPlugin);
+        }
+        blackhole.consume(state.populatedStore);
+    }
+
+    @Benchmark
+    public void removeNew(Blackhole blackhole, NewStoreRead state) {
+        for (Block block : blocks) {
+            state.populatedStore.removeMetadata(block, key, state.owningPlugin);
+        }
+        blackhole.consume(state.populatedStore);
+    }
+
+    private static Block[] generateBlocks() {
+        Block[] blocks = new Block[20];
+        for (int x = 2, y = 0, z = 2, i = 0; i < blocks.length; i++, x += 300, z += 200, y += 10) {
+            blocks[i] = makeBlock(x, y, z);
+        }
+        return blocks;
+    }
+
+    private static Block makeBlock(int x, int y, int z) {
+        return new TestBlock(x, y, z);
+    }
+
+    private static class TestPlugin implements Plugin {
+
+    }
+
+    private static class TestBlock implements Block {
+        private final int x;
+        private final int y;
+        private final int z;
+
+        protected TestBlock(int x, int y, int z) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+
+        @Override
+        public int getX() {
+            return x;
+        }
+
+        @Override
+        public int getY() {
+            return y;
+        }
+
+        @Override
+        public int getZ() {
+            return z;
+        }
+
+        @Override
+        public World getWorld() {
+            return null;
+        }
+    }
+}

--- a/Benchmarks/src/main/java/org/bukkit/plugin/Plugin.java
+++ b/Benchmarks/src/main/java/org/bukkit/plugin/Plugin.java
@@ -1,0 +1,7 @@
+package org.bukkit.plugin;
+
+/**
+ * Overwritten to only use the methods we need
+ */
+public interface Plugin {
+}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ Once it's done, you'll have a `Paperclip.jar` file in the project directory.
 ### Running benchmarks
 To run benchmarks, first build the server normally, then run these commands:
 ```shell
-mvn install -P benchmarks
+# Run these two commands sequentially, not together
+mvn compile -P benchmarks
+mvn package -P benchmarks
+
 java -jar Benchmarks/target/paper-benchmarks.jar
 ```
 

--- a/Spigot-Server-Patches/0232-Add-specialized-BlockMetadataStore.patch
+++ b/Spigot-Server-Patches/0232-Add-specialized-BlockMetadataStore.patch
@@ -1,0 +1,316 @@
+From f23c6d75555bd13fe5d17c45875dcd3639106b73 Mon Sep 17 00:00:00 2001
+From: RoccoDev <hey@rocco.dev>
+Date: Fri, 1 Apr 2022 00:54:39 +0200
+Subject: [PATCH] Add specialized BlockMetadataStore
+
+
+diff --git a/pom.xml b/pom.xml
+index f4047f9a5..8ca3bbe07 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -120,6 +120,12 @@
+             <artifactId>log4j-core</artifactId>
+             <version>2.17.1</version>
+         </dependency>
++        <dependency>
++            <groupId>org.mockito</groupId>
++            <artifactId>mockito-core</artifactId>
++            <version>4.4.0</version>
++            <scope>test</scope>
++        </dependency>
+         <!-- // KigPaper end -->
+     </dependencies>
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index 949c58a41..0f218a046 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -42,6 +42,7 @@ import org.bukkit.craftbukkit.block.CraftBlockState;
+ import org.bukkit.craftbukkit.entity.*;
+ import org.bukkit.craftbukkit.inventory.CraftItemStack;
+ import org.bukkit.craftbukkit.metadata.BlockMetadataStore;
++import org.bukkit.craftbukkit.metadata.SpecializedBlockMetadataStore;
+ import org.bukkit.craftbukkit.util.CraftMagicNumbers;
+ import org.bukkit.craftbukkit.util.LongHash;
+ import org.bukkit.entity.*;
+@@ -56,6 +57,7 @@ import org.bukkit.event.world.SpawnChangeEvent;
+ import org.bukkit.generator.BlockPopulator;
+ import org.bukkit.generator.ChunkGenerator;
+ import org.bukkit.inventory.ItemStack;
++import org.bukkit.metadata.MetadataStore;
+ import org.bukkit.metadata.MetadataValue;
+ import org.bukkit.plugin.Plugin;
+ import org.bukkit.plugin.messaging.StandardMessenger;
+@@ -71,7 +73,10 @@ public class CraftWorld implements World {
+     private final CraftServer server = (CraftServer) Bukkit.getServer();
+     private final ChunkGenerator generator;
+     private final List<BlockPopulator> populators = new ArrayList<BlockPopulator>();
+-    private final BlockMetadataStore blockMetadata = new BlockMetadataStore(this);
++    // KigPaper start
++    //private final BlockMetadataStore blockMetadata = new BlockMetadataStore(this);
++    private final MetadataStore<Block> blockMetadata = new SpecializedBlockMetadataStore(this);
++    // KigPaper end
+     private int monsterSpawn = -1;
+     private int animalSpawn = -1;
+     private int waterAnimalSpawn = -1;
+@@ -862,7 +867,7 @@ public class CraftWorld implements World {
+         return Difficulty.getByValue(this.getHandle().getDifficulty().ordinal());
+     }
+ 
+-    public BlockMetadataStore getBlockMetadata() {
++    public MetadataStore<Block> getBlockMetadata() { // KigPaper - change type
+         return blockMetadata;
+     }
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/metadata/SpecializedBlockMetadataStore.java b/src/main/java/org/bukkit/craftbukkit/metadata/SpecializedBlockMetadataStore.java
+new file mode 100644
+index 000000000..3f2a13b89
+--- /dev/null
++++ b/src/main/java/org/bukkit/craftbukkit/metadata/SpecializedBlockMetadataStore.java
+@@ -0,0 +1,175 @@
++package org.bukkit.craftbukkit.metadata;
++
++import com.google.common.base.Objects;
++import com.google.common.base.Preconditions;
++import com.google.common.collect.ImmutableList;
++import org.bukkit.Location;
++import org.bukkit.World;
++import org.bukkit.block.Block;
++import org.bukkit.metadata.MetadataStore;
++import org.bukkit.metadata.MetadataValue;
++import org.bukkit.plugin.Plugin;
++
++import java.util.*;
++
++/**
++ * An alternative to {@link BlockMetadataStore} that uses specialized collections and bit-packing for faster
++ * operations and a lower memory footprint.
++ *
++ * <p>This can be a drop-in replacement, though keep in mind methods will throw an {@link IllegalArgumentException}
++ * if invalid block coordinates are provided.
++ */
++public class SpecializedBlockMetadataStore implements MetadataStore<Block> {
++    // Allows storing 25 bits (up to 33,554,432 - MC supports up to 30,000,000) + sign
++    private static final int MASK_26_BITS = 0b111_111_111_111_111_111_111_111_11;
++
++    private final Map<StoreKey, Map<Plugin, MetadataValue>> metadata = new HashMap<>();
++    private final World owningWorld;
++
++    // Cached key used for (synchronized) lookups, saves allocations.
++    // The key stored inside is usually cleared after use, so that the reference doesn't live too long.
++    private final StoreKey cachedKey = new StoreKey(null, 0);
++
++    public SpecializedBlockMetadataStore(World owningWorld) {
++        this.owningWorld = owningWorld;
++    }
++
++    @Override
++    public synchronized List<MetadataValue> getMetadata(Block block, String metadataKey) {
++        Preconditions.checkArgument(block.getWorld() == owningWorld, "block is from another world");
++
++        List<MetadataValue> list = Collections.emptyList();
++        Map<Plugin, MetadataValue> pluginMetadata = getEntry(metadataKey, block);
++        if (pluginMetadata == null) {
++            return list;
++        }
++        list = ImmutableList.copyOf(pluginMetadata.values());
++
++        return list;
++    }
++
++    @Override
++    public synchronized boolean hasMetadata(Block block, String metadataKey) {
++        Preconditions.checkArgument(block.getWorld() == owningWorld, "block is from another world");
++        Map<Plugin, MetadataValue> pluginMetadata = getEntry(metadataKey, block);
++        return pluginMetadata != null && !pluginMetadata.isEmpty();
++    }
++
++    @Override
++    public synchronized void removeMetadata(Block block, String metadataKey, Plugin owningPlugin) {
++        Preconditions.checkArgument(block.getWorld() == owningWorld, "block is from another world");
++        Preconditions.checkNotNull(owningPlugin, "plugin is null");
++
++        long id = getBlockId(block);
++        Map<Plugin, MetadataValue> pluginMetadata = getEntry(metadataKey, id);
++        if (pluginMetadata == null) {
++            return;
++        }
++        // Clear empty entries
++        if (pluginMetadata.remove(owningPlugin) != null && pluginMetadata.isEmpty()) {
++            StoreKey key = getCachedKey(metadataKey, id);
++            this.metadata.remove(key);
++            key.metadataKey = null;
++        }
++    }
++
++    @Override
++    public synchronized void setMetadata(Block block, String metadataKey, MetadataValue newMetadataValue) {
++        Preconditions.checkArgument(block.getWorld() == owningWorld, "block is from another world");
++        Preconditions.checkNotNull(newMetadataValue, "value is null");
++        Plugin owningPlugin = newMetadataValue.getOwningPlugin();
++        Preconditions.checkNotNull(owningPlugin, "plugin is null");
++
++        Map<Plugin, MetadataValue> entry = metadata.computeIfAbsent(new StoreKey(metadataKey, getBlockId(block)),
++                k -> new WeakHashMap<>(1));
++        entry.put(owningPlugin, newMetadataValue);
++    }
++
++    @Override
++    public synchronized void invalidateAll(Plugin owningPlugin) {
++        Preconditions.checkNotNull(owningPlugin, "plugin is null");
++        for (Map<Plugin, MetadataValue> values : metadata.values()) {
++            MetadataValue value = values.get(owningPlugin);
++            if (value != null) {
++                value.invalidate();
++            }
++        }
++    }
++
++    private Map<Plugin, MetadataValue> getEntry(String key, Block block) {
++        return getEntry(key, getBlockId(block));
++    }
++
++    private Map<Plugin, MetadataValue> getEntry(String key, long id) {
++        StoreKey storeKey = getCachedKey(key, id);
++        Map<Plugin, MetadataValue> ret = metadata.get(storeKey);
++        storeKey.metadataKey = null;
++        return ret;
++    }
++
++    private StoreKey getCachedKey(String metadataKey, long id) {
++        cachedKey.block = id;
++        cachedKey.metadataKey = metadataKey;
++        return cachedKey;
++    }
++
++    static long getBlockId(Block block) {
++        int x = block.getX();
++        int y = block.getY();
++        int z = block.getZ();
++        Preconditions.checkArgument(x >= -30_000_000 && x <= 30_000_000,
++                "block X out of range");
++        Preconditions.checkArgument(y >= 0 && y <= 255, "block Y out of range");
++        Preconditions.checkArgument(z >= -30_000_000 && z <= 30_000_000,
++                "block Z out of range");
++        // X (26 bits) + Y (8 bits) + Z (26 bits)
++        return ((long) (x & MASK_26_BITS) << 34) | ((long) (y & 0xFF) << 26) | (z & MASK_26_BITS);
++    }
++
++    /**
++     * Used for tests.
++     */
++    static Location toLocation(World world, long id) {
++        int x = (int) (id >> 34);
++        int y = (int) ((id >> 26) & 0xFF);
++        int z = (int) id;
++
++        // Restore sign
++        if ((x & (1 << 25)) > 0) {
++            x |= ~MASK_26_BITS;
++        } else {
++            x &= MASK_26_BITS;
++        }
++
++        if ((z & (1 << 25)) > 0) {
++            z |= ~MASK_26_BITS;
++        } else {
++            z &= MASK_26_BITS;
++        }
++
++        return new Location(world, x, y, z);
++    }
++
++    private static class StoreKey {
++        private String metadataKey;
++        private long block;
++
++        private StoreKey(String metadataKey, long block) {
++            this.metadataKey = metadataKey;
++            this.block = block;
++        }
++
++        @Override
++        public boolean equals(Object o) {
++            if (this == o) return true;
++            if (o == null || getClass() != o.getClass()) return false;
++            StoreKey storeKey = (StoreKey) o;
++            return block == storeKey.block && Objects.equal(metadataKey, storeKey.metadataKey);
++        }
++
++        @Override
++        public int hashCode() {
++            return Objects.hashCode(metadataKey, block);
++        }
++    }
++}
+diff --git a/src/test/java/org/bukkit/craftbukkit/metadata/BlockMetadataTest.java b/src/test/java/org/bukkit/craftbukkit/metadata/BlockMetadataTest.java
+new file mode 100644
+index 000000000..5f99fcfe9
+--- /dev/null
++++ b/src/test/java/org/bukkit/craftbukkit/metadata/BlockMetadataTest.java
+@@ -0,0 +1,62 @@
++package org.bukkit.craftbukkit.metadata;
++
++import org.bukkit.Location;
++import org.bukkit.block.Block;
++import org.bukkit.metadata.FixedMetadataValue;
++import org.bukkit.metadata.MetadataStore;
++import org.bukkit.metadata.MetadataValue;
++import org.bukkit.plugin.Plugin;
++import org.junit.Assert;
++import org.junit.Test;
++import org.mockito.Mockito;
++
++import java.util.List;
++
++public class BlockMetadataTest {
++    @Test
++    public void oldNewComparison() {
++        MetadataStore<Block> oldStore = new BlockMetadataStore(null);
++        MetadataStore<Block> newStore = new SpecializedBlockMetadataStore(null);
++        Plugin plugin = Mockito.mock(Plugin.class);
++
++        for (int x = 2, y = 0, z = 2, i = 0; i < 20; i++, x += 300, z += 200, y += 10) {
++            Block block = makeBlock(i % 2 == 0 ? x : -x, y, i % 2 == 0 ? z : -z);
++            MetadataValue value = new FixedMetadataValue(plugin, i);
++
++            oldStore.setMetadata(block, "test", value);
++            oldStore.setMetadata(block, "test" + i, value);
++            newStore.setMetadata(block, "test", value);
++            newStore.setMetadata(block, "test" + i, value);
++
++            Assert.assertTrue(newStore.hasMetadata(block, "test"));
++            Assert.assertTrue(newStore.hasMetadata(block, "test" + i));
++
++            List<MetadataValue> test = newStore.getMetadata(block, "test");
++            Assert.assertEquals(test, oldStore.getMetadata(block, "test"));
++            Assert.assertTrue("value in newStore[\"test\"]", test.contains(value));
++
++            List<MetadataValue> indexTest = newStore.getMetadata(block, "test" + i);
++            Assert.assertEquals(indexTest, oldStore.getMetadata(block, "test" + i));
++            Assert.assertTrue("value in newStore[\"test\" + i]", indexTest.contains(value));
++        }
++    }
++
++    @Test
++    public void compareIds() {
++        for (int x = 3, y = 1, z = 2, i = 0; i < 20; i++, x += 300, z += 200, y += 10) {
++            Block block = makeBlock(i % 2 == 0 ? x : -x, y, i % 2 == 0 ? z : -z);
++            Location location = new Location(null, block.getX(), block.getY(), block.getZ());
++
++            Assert.assertEquals(location, SpecializedBlockMetadataStore.toLocation(null,
++                    SpecializedBlockMetadataStore.getBlockId(block)));
++        }
++    }
++
++    private static Block makeBlock(int x, int y, int z) {
++        Block block = Mockito.mock(Block.class);
++        Mockito.when(block.getX()).thenReturn(x);
++        Mockito.when(block.getY()).thenReturn(y);
++        Mockito.when(block.getZ()).thenReturn(z);
++        return block;
++    }
++}
+-- 
+2.35.1
+


### PR DESCRIPTION
This adds a drop-in alternative to CraftBukkit's `BlockMetadataStore`, aiming to reduce memory footprint and increase performance.

Here are some benchmark results from my machine (Ryzen 5 3600 @ 3.6 GHz, 3200 MHz RAM), with regular warmup/measurement iterations but only one fork. (YMMV)
<table>
<tr>
	<td><b>Operation</b>
	<td><b>Old</b> (op/s)
	<td><b>New</b> (op/s)
	<td><b>Delta</b>
<tr>
	<td>get
	<td>341,332 ± 5,531
	<td>3,224,111 ± 148,786
	<td>+944%
<tr>
	<td>contains
	<td>315,856 ± 32,095
	<td>3,050,975 ± 362,347
	<td>+965%
<tr>
	<td>insert
	<td>257,185 ± 4,249
	<td>797,096 ± 152,187
	<td>+309%
<tr>
	<td>remove
	<td>327,822 ± 36,262
	<td>3,173,584 ± 758,450
	<td>+968%
</table>

Additionally, for a table of 20 blocks with one metadata pair each, there is a 20% size decrease. (5.9 KB -> 4.7 KB)

You can run benchmarks using these commands:
```sh
mvn compile -P benchmarks
mvn package -P benchmarks

java -jar Benchmarks/target/paper-benchmarks.jar
```
(The first two commands are hit-or-miss sometimes, if you get compilation errors just try again)

I had originally planned to use a primitive collection (`TIntObjectHashMap`), though that required an extra map inside. I think it's only justified if many metadata pairs are created for one block, to get better hash performance.

It's worth noting that this also adds Mockito as a test dependency on `paperspigot-server`, as per your suggestion.