### PR TITLE
Use new SHA1 server download link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,8 @@
 	url = https://hub.spigotmc.org/stash/scm/spigot/craftbukkit.git
 [submodule "BuildData"]
 	path = BuildData
-	url = https://hub.spigotmc.org/stash/scm/spigot/builddata.git
+	url = https://github.com/ProjectKig/BuildData.git
+	branch = ver/1.8.8
 [submodule "Paperclip"]
 	path = Paperclip
 	url = https://github.com/ProjectKig/Old-Paperclip.git

--- a/remap.sh
+++ b/remap.sh
@@ -14,7 +14,7 @@ jarpath=$workdir/$minecraftversion/$minecraftversion
 echo "Downloading unmapped vanilla jar..."
 if [ ! -f  "$jarpath.jar" ]; then
     mkdir -p "$workdir/$minecraftversion"
-    curl -s -o "$jarpath.jar" "https://s3.amazonaws.com/Minecraft.Download/versions/$minecraftversion/minecraft_server.$minecraftversion.jar"
+    curl -s -o "$jarpath.jar" "https://launcher.mojang.com/v1/objects/$minecrafthash/server.jar"
     if [ "$?" != "0" ]; then
         echo "Failed to download the vanilla server jar. Check connectivity or try again later."
         exit 1
@@ -24,13 +24,13 @@ fi
 # OS X doesn't have md5sum, just md5 -r
 if [[ "$OSTYPE" == "darwin"* ]]; then
    shopt -s expand_aliases
-   alias md5sum='md5 -r'
-   echo "Using an alias for md5sum on OS X"
+   alias sha1sum='shasum -a 1'
+   echo "Using an alias for sha1sum on OS X"
 fi
 
-checksum=$(md5sum "$jarpath.jar" | cut -d ' ' -f 1)
+checksum=$(sha1sum "$jarpath.jar" | cut -d ' ' -f 1)
 if [ "$checksum" != "$minecrafthash" ]; then
-    echo "The MD5 checksum of the downloaded server jar does not match the BuildData hash."
+    echo "The SHA1 checksum of the downloaded server jar does not match the BuildData hash."
     exit 1
 fi
 


### PR DESCRIPTION
Microsoft seems to have removed the Amazon AWS link, so this commit replaces the old link with the new launcher link. Because the new link contains the server's SHA1 hash, this commit replaces all MD5 checks for the server with SHA1.

I tried to include a fix for macOS installations, as they might not bundle `sha1sum` by default, but I couldn't test this.