### PR TITLE
Replaced commands not supported by default on Windows in build scripts

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -21,7 +21,9 @@ mkdir -p $cb
 for file in nms-patches/* "$basedir"/nms-patches/*
 do
     patchFile="$file"
-    file="$(echo "$file" | rev | cut -d/ -f1 | rev | cut -d. -f1).java"
+    filename="${file##*/}"
+    filename="${filename%.*}"
+    file="$filename.java"
 
     echo "Patching $file < $patchFile"
     sed -i 's/\r//' "$nms/$file" > /dev/null

--- a/remap.sh
+++ b/remap.sh
@@ -38,7 +38,14 @@ fi
 echo "KIG: Removing dependencies..."
 if [ ! -f "$jarpath-kig-nodeps.jar" ]; then
     cp "$jarpath.jar" "$jarpath-kig-nodeps.jar" 1>/dev/null
-    zip -d "$jarpath-kig-nodeps.jar" org/apache/logging/log4j/* io/netty/* META-INF/io.netty.*
+    mkdir -p "$workdir/tmp_kig"
+    (
+        cd "$workdir/tmp_kig"
+        jar xf "$jarpath.jar"
+        rm -rf org/apache/logging/log4j io/netty META-INF/io.netty.*
+        jar cf "$jarpath-kig-nodeps.jar" .
+    )
+    rm -rf "$workdir/tmp_kig"
     echo "KIG: Removed dependencies from vanilla jar. Make sure to have them in pom.xml!"
 fi
 # KigPaper end

--- a/remap.sh
+++ b/remap.sh
@@ -37,15 +37,14 @@ fi
 # KigPaper start - Remove log4j & other deps from vanilla jar
 echo "KIG: Removing dependencies..."
 if [ ! -f "$jarpath-kig-nodeps.jar" ]; then
-    cp "$jarpath.jar" "$jarpath-kig-nodeps.jar" 1>/dev/null
     mkdir -p "$workdir/tmp_kig"
     (
         cd "$workdir/tmp_kig"
         jar xf "$jarpath.jar"
-        rm -rf org/apache/logging/log4j io/netty META-INF/io.netty.*
+        rm -r org/apache/logging/log4j io/netty META-INF/io.netty.*
         jar cf "$jarpath-kig-nodeps.jar" .
     )
-    rm -rf "$workdir/tmp_kig"
+    rm -r "$workdir/tmp_kig"
     echo "KIG: Removed dependencies from vanilla jar. Make sure to have them in pom.xml!"
 fi
 # KigPaper end


### PR DESCRIPTION
Replaced `rev` and `zip` in the build scripts since they aren't supported by Git Bash on Windows by default.